### PR TITLE
Support the title attribute in optionRenderer for tooltips

### DIFF
--- a/source/VirtualizedSelect/VirtualizedSelect.js
+++ b/source/VirtualizedSelect/VirtualizedSelect.js
@@ -177,6 +177,7 @@ export default class VirtualizedSelect extends Component {
         className={className.join(' ')}
         key={key}
         style={style}
+        title={option.title}
         {...events}
       >
         {option[labelKey]}


### PR DESCRIPTION
Hi! Great component!

This PR adds support for the title attribute in optionRenderer like the underlying react-select component: https://github.com/JedWatson/react-select/blob/master/src/Option.js#L89

This is of course backward compatible, i.e. nothing changes for those who don't have value for `option.title`.