### PR TITLE
Use cdn.rawgit.com for flag images in the demo

### DIFF
--- a/source/VirtualizedSelect/VirtualizedSelect.example.js
+++ b/source/VirtualizedSelect/VirtualizedSelect.example.js
@@ -217,7 +217,7 @@ export default class VirtualizedSelectExample extends Component {
 }
 
 function CountryOptionRenderer ({ focusedOption, focusedOptionIndex, focusOption, key, labelKey, option, options, selectValue, style, valueArray }) {
-  const flagImageUrl = `https://rawgit.com/hjnilsson/country-flags/master/svg/${option.code.toLowerCase()}.svg`
+  const flagImageUrl = `https://cdn.rawgit.com/hjnilsson/country-flags/9e827754/svg/${option.code.toLowerCase()}.svg`
 
   const classNames = [styles.countryOption]
   if (option === focusedOption) {


### PR DESCRIPTION
The countries dropdown in the demo was loading flag images from a `rawgit.com` development URL, which is [not intended for use on public-facing websites](https://github.com/rgrove/rawgit/blob/55f1d746880144d81b8972671ba3f4cd933eefb9/FAQ.md#can-i-use-a-development-url-on-a-production-website-or-in-public-example-code) because it puts excessive load on both RawGit and GitHub, especially in a case like this where many images are requested at once.

I've updated the example to use a `cdn.rawgit.com` URL instead. The RawGit CDN will aggressively cache the images and is capable of handling whatever load this example can generate without causing undue strain on RawGit or GitHub.