### PR TITLE
Revert "Backwards compat bugfix for require('...').default usecase (s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ------------
 
+##### 3.0.1
+* Revert v2.4.2, https://github.com/bvaughn/react-virtualized-select/issues/57#issuecomment-297742641
+
 ##### 3.0.0
 * Same as v2.4.2 but with an updated external dependency versions (eg react-virtualized 8.x to 9.x, new prop-types lib, react alpha 16, etc).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-virtualized-select",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Drop-down menu for React with windowing to support large numbers of options.",
   "main": "dist/commonjs/index.js",
   "jsnext:main": "dist/es/index.js",

--- a/source/index.js
+++ b/source/index.js
@@ -1,8 +1,2 @@
 /* @flow */
-import VirtualizedSelect from './VirtualizedSelect'
-
-// Backwards compatible hack for require('...').default
-// See bvaughn/react-virtualized-select/issues/57
-VirtualizedSelect.default = VirtualizedSelect
-
-module.exports = VirtualizedSelect
+export default from './VirtualizedSelect'


### PR DESCRIPTION
…ee issue #57)"

This reverts commit 2b2368a008ec16ae30e101d124a2ccc46612a5ce.

re: https://github.com/bvaughn/react-virtualized-select/issues/57#issuecomment-297737729