### PR TITLE
Custom Option Renderer style paramater description

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,5 @@ You can override the built-in option renderer by specifying your own `optionRend
 | option | `PropTypes.object` | The option to be rendered. |
 | options | `PropTypes.arrayOf(PropTypes.object)` | Array of options (objects) contained in the select menu. |
 | selectValue | `PropTypes.func` | Callback to update the selected values; for example, you may want to call this function on click. |
+| style | `PropTypes.object` | Styles that must be passed to the rendered option. These styles are specifying the position of each option (required for correct option displaying in the dropdown).
 | valueArray | `PropTypes.arrayOf(PropTypes.object)` | Array of the currently-selected options. Use this property to determine if your rendered option should be highlighted or styled differently. |


### PR DESCRIPTION
Added `style` parameter to Custom Option Renderer parameters table. Styles must be applied to the rendered option for correct displaying in the dropdown. Lack of styles leads to the dropdown "shaking" effect during scrolling - options are auto-added and then insta-auto-removed from the dropdown.