### PR TITLE
Avoid redundant focusOption function calls

### DIFF
--- a/source/VirtualizedSelect/VirtualizedSelect.example.js
+++ b/source/VirtualizedSelect/VirtualizedSelect.example.js
@@ -233,7 +233,7 @@ function CountryOptionRenderer ({ focusedOption, focusedOptionIndex, focusOption
       className={classNames.join(' ')}
       key={key}
       onClick={() => selectValue(option)}
-      onMouseOver={() => focusOption(option)}
+      onMouseEnter={() => focusOption(option)}
       style={style}
     >
       <label className={styles.countryLabel}>
@@ -275,7 +275,7 @@ function NameOptionRenderer ({ focusedOption, focusedOptionIndex, focusOption, k
         className={classNames.join(' ')}
         key={key}
         onClick={() => selectValue(option)}
-        onMouseOver={() => focusOption(option)}
+        onMouseEnter={() => focusOption(option)}
         style={style}
       >
         {option.name}

--- a/source/VirtualizedSelect/VirtualizedSelect.js
+++ b/source/VirtualizedSelect/VirtualizedSelect.js
@@ -174,7 +174,7 @@ export default class VirtualizedSelect extends Component {
       ? {}
       : {
         onClick: () => selectValue(option),
-        onMouseOver: () => focusOption(option)
+        onMouseEnter: () => focusOption(option)
       }
 
     return (


### PR DESCRIPTION
Avoid redundant event calls when option child nodes are hovered.