### PR TITLE
satisfies demo data for linter

### DIFF
--- a/source/demo/data/cities.js
+++ b/source/demo/data/cities.js
@@ -924,4 +924,4 @@ export default [
   { name: 'Yuba City', disabled: true },
   { name: 'Yucaipa', disabled: true },
   { name: 'Yuma', disabled: true }
-];
+]


### PR DESCRIPTION
Removes semi-colon from which is causing `npm run lint` to fail. Not sure why the linter doesn't think there should be a semi-colon there but upgrading the "standard" npm package did not help.

```
standard: Use JavaScript Standard Style (https://github.com/feross/standard)
  /Users/admin/dev/react-virtualized-select/source/demo/data/cities.js:927:2: Extra semicolon.
```