### PR TITLE
Lock version of react-virtualized

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "react-select": "^1.0.0-rc.2",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",
-    "react-virtualized": "^9.0.0",
     "redbox-react": "^1.0.1",
     "rimraf": "^2.4.3",
     "standard": "^5.4.1",
@@ -122,7 +121,7 @@
     "babel-runtime": "^6.11.6",
     "prop-types": "^15.5.8",
     "react-select": "^1.0.0-rc.2",
-    "react-virtualized": "^9.0.0"
+    "react-virtualized": "9.18.3"
   },
   "peerDependencies": {
     "react": "^15.3.0 || ^16.0.0-alpha",


### PR DESCRIPTION
Due to https://github.com/bvaughn/react-virtualized/issues/993 module bundlers fail when trying to include react-virtualized. This PR locks the version of RV so that projects (Like mine!) which include react-virtualized-select but do not explicitly install RV do not suffer from this problem. 

I also removed the duplicate definition of that package (Left it in `dependencies` and removed from `devDependencies`).